### PR TITLE
feat: detailpage의 수정하기 버튼 추가

### DIFF
--- a/src/pages/DetailPage/DetailPage.js
+++ b/src/pages/DetailPage/DetailPage.js
@@ -3,6 +3,7 @@ import Header from '../../components/layout/Header';
 import cardBtn from '../../assets/icons/cardBtn.png';
 import { Link } from 'react-router-dom';
 import React from 'react';
+import Button from '../../components/ui/Button';
 
 const DetailPageContainer = styled.div`
   width: 100%;
@@ -20,7 +21,7 @@ const DetailPageCardContainer = styled.div`
   flex-wrap: wrap;
   gap: 2.4rem;
   position: relative;
-  margin-top: 127px;
+  margin-top: 18px;
 
   @media (max-width: 1248px) {
     width: calc(100% - 4.8rem);
@@ -52,7 +53,28 @@ const DetailPageCard = styled.div`
   }
 `;
 
-const BtnLink = styled(Link)`
+const DetailPageEditBtn = styled(Button)`
+  width: 9.2rem;
+`;
+
+const DetailPageEditBtnContainer = styled.div`
+  width: 120rem; // desktop에서는 120px 고정
+  height: 3.9;
+  margin: 6.3rem auto 0 auto;
+  display: flex;
+  justify-content: flex-end;
+
+  @media (max-width: 1248px) {
+    width: calc(100% - 4.8rem);
+    gap: 1.6rem;
+  }
+
+  @media (max-width: 768px) {
+    width: calc(100% - 4.8rem);
+  }
+`;
+
+const DetailPageCardCreateBtn = styled(Link)`
   width: 38.4rem;
   height: 28rem;
   border-radius: 1.6rem;
@@ -76,21 +98,39 @@ const BtnLink = styled(Link)`
 
 const id = 3; // 임시 처리
 
+// 임시 카드 배열 데이터 id와 함께 api 작업 가져오면 변경
+const cardData = [
+  { id: 1, imageUrl: cardBtn },
+  { id: 2, imageUrl: cardBtn },
+  { id: 3, imageUrl: cardBtn },
+  { id: 4, imageUrl: cardBtn },
+  { id: 5, imageUrl: cardBtn },
+  { id: 6, imageUrl: cardBtn },
+  { id: 7, imageUrl: cardBtn },
+];
+
 function DetailPage() {
   return (
     <>
       <Header />
       <DetailPageContainer>
+        <DetailPageEditBtnContainer>
+          <Link to={`/post/${id}/edit`}>
+            <DetailPageEditBtn
+              size={40}
+              label="수정하기"
+              variant="primary"
+              fullWidth={92}
+            />
+          </Link>
+        </DetailPageEditBtnContainer>
         <DetailPageCardContainer>
-          <BtnLink to={`/post/${id}/message`}>
+          <DetailPageCardCreateBtn to={`/post/${id}/message`}>
             <img src={cardBtn} alt="" />
-          </BtnLink>
-          <DetailPageCard></DetailPageCard>
-          <DetailPageCard></DetailPageCard>
-          <DetailPageCard></DetailPageCard>
-          <DetailPageCard></DetailPageCard>
-          <DetailPageCard></DetailPageCard>
-          <DetailPageCard></DetailPageCard>
+          </DetailPageCardCreateBtn>
+          {cardData.map((card) => (
+            <DetailPageCard key={card.id}></DetailPageCard>
+          ))}
         </DetailPageCardContainer>
       </DetailPageContainer>
     </>


### PR DESCRIPTION
### 작업 내용
- 디테일 페이지의  수정하기 버튼 기능구현 : 수정하기 버튼을 누르면 /post/{id}/edit 로 이동하게 합니다.

![image](https://github.com/user-attachments/assets/c9d14e94-cba2-45cd-8f58-a583bb759cd3)

  
### 고려 사항
- DetailPageCard는 따로 분리해서 DetailPage 에서 map 사용해서 렌더링으로 수정
- Button.js 컴포넌트 재사용
- 우선적으로는 단순하게 페이지 이동만 기능을 하지만 **추후에** id값에 따른 비밀번호를 생성시에 지정해서
   수정하기 버튼을 누르면 비밀번호를 입력하고 허가시에만 이동하게 하는 방향으로 해도 좋을 것 같습니다



Resolves #12 