### PR TITLE
Refactor/responsive carousel custom #17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^6.28.0",
         "react-scripts": "5.0.1",
-        "styled-components": "^6.1.13",
-        "swiper": "^11.1.15"
+        "styled-components": "^6.1.13"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.6.0",
@@ -18432,25 +18431,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/swiper": {
-      "version": "11.1.15",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.15.tgz",
-      "integrity": "sha512-IzWeU34WwC7gbhjKsjkImTuCRf+lRbO6cnxMGs88iVNKDwV+xQpBCJxZ4bNH6gSrIbbyVJ1kuGzo3JTtz//CBw==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.28.0",
     "react-scripts": "5.0.1",
-    "styled-components": "^6.1.13",
-    "swiper": "^11.1.15"
+    "styled-components": "^6.1.13"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.0",

--- a/src/pages/ListPage/CarouselContainer.js
+++ b/src/pages/ListPage/CarouselContainer.js
@@ -1,0 +1,65 @@
+import { useState, useRef } from 'react';
+import CarouselPresenter from './CarouselPresenter';
+
+function CarouselContainer({
+  data,
+  isMobile,
+  currentIndex,
+  handlePrev,
+  handleNext,
+  maxIndex,
+  cardsToShow,
+}) {
+  // 드래그를 위한 상태와 ref
+  const containerRef = useRef(null);
+  const [isDown, setIsDown] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  const onMouseDown = (e) => {
+    const container = containerRef.current;
+    setIsDown(true);
+    container.classList.add('grabbing');
+    setStartX(e.pageX - container.offsetLeft);
+    setScrollLeft(container.scrollLeft);
+  };
+
+  const onMouseLeave = () => {
+    if (!isDown) return;
+    setIsDown(false);
+    containerRef.current.classList.remove('grabbing');
+  };
+
+  const onMouseUp = () => {
+    setIsDown(false);
+    containerRef.current.classList.remove('grabbing');
+  };
+
+  const onMouseMove = (e) => {
+    if (!isDown) return;
+    e.preventDefault();
+    const container = containerRef.current;
+    const x = e.pageX - container.offsetLeft;
+    const walk = x - startX;
+    container.scrollLeft = scrollLeft - walk;
+  };
+
+  return (
+    <CarouselPresenter
+      data={data}
+      isMobile={isMobile}
+      currentIndex={currentIndex}
+      handlePrev={handlePrev}
+      handleNext={handleNext}
+      maxIndex={maxIndex}
+      cardsToShow={cardsToShow}
+      containerRef={containerRef}
+      onMouseDown={onMouseDown}
+      onMouseLeave={onMouseLeave}
+      onMouseUp={onMouseUp}
+      onMouseMove={onMouseMove}
+    />
+  );
+}
+
+export default CarouselContainer;

--- a/src/pages/ListPage/CarouselPresenter.js
+++ b/src/pages/ListPage/CarouselPresenter.js
@@ -1,6 +1,4 @@
-import React from 'react';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import 'swiper/css';
+import styled from 'styled-components';
 import ListPageCard from './ListPageCard';
 import CarouselButton from '../../components/common/CarouselButton';
 import {
@@ -8,8 +6,34 @@ import {
   CarouselInnerWrapper,
   CardsContainer,
 } from './ListPage.styles';
+import CarouselContainer from './CarouselContainer';
 
-function ResponsiveCarousel({
+const MobileScrollContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  cursor: grab;
+  &.grabbing {
+    cursor: grabbing;
+  }
+`;
+
+const SlideWrapper = styled.div`
+  flex: 0 0 auto;
+  width: 27.5rem;
+  height: 26rem;
+  overflow: hidden;
+`;
+
+function CarouselPresenter({
   data,
   isMobile,
   currentIndex,
@@ -17,25 +41,29 @@ function ResponsiveCarousel({
   handleNext,
   maxIndex,
   cardsToShow,
+  containerRef,
+  onMouseDown,
+  onMouseLeave,
+  onMouseUp,
+  onMouseMove,
 }) {
   if (isMobile) {
-    const slideStyle = {
-      width: '275px',
-      height: '260px',
-      overflow: 'hidden',
-    };
-
     return (
-      <Swiper spaceBetween={20} slidesPerView="auto" grabCursor={true}>
+      <MobileScrollContainer
+        ref={containerRef}
+        onMouseDown={onMouseDown}
+        onMouseLeave={onMouseLeave}
+        onMouseUp={onMouseUp}
+        onMouseMove={onMouseMove}
+      >
         {data.map((item) => (
-          <SwiperSlide key={item.id} style={slideStyle}>
+          <SlideWrapper key={item.id}>
             <ListPageCard data={item} />
-          </SwiperSlide>
+          </SlideWrapper>
         ))}
-      </Swiper>
+      </MobileScrollContainer>
     );
   }
-
   // 데스크톱일 경우
   return (
     <CarouselOuterWrapper>
@@ -60,4 +88,4 @@ function ResponsiveCarousel({
   );
 }
 
-export default ResponsiveCarousel;
+export default CarouselPresenter;

--- a/src/pages/ListPage/ListPage.js
+++ b/src/pages/ListPage/ListPage.js
@@ -10,7 +10,7 @@ import {
   ListSection,
   StyledLink,
 } from './ListPage.styles';
-import ResponsiveCarousel from './ResponsiveCarousel';
+import CarouselContainer from './CarouselContainer';
 
 function ListPage() {
   const cardsToShow = 4;
@@ -39,7 +39,7 @@ function ListPage() {
         <SectionWrapper>
           <h2 className="text-xl font-bold">인기 롤링 페이퍼 🔥</h2>
           <ListSection>
-            <ResponsiveCarousel
+            <CarouselContainer
               data={mockData}
               isMobile={isMobile}
               currentIndex={currentIndexTop}
@@ -54,7 +54,7 @@ function ListPage() {
         <SectionWrapper>
           <h2 className="text-xl font-bold">최근에 만든 롤링 페이퍼 ⭐️️</h2>
           <ListSection>
-            <ResponsiveCarousel
+            <CarouselContainer
               data={mockData}
               isMobile={isMobile}
               currentIndex={currentIndexBottom}


### PR DESCRIPTION
## 작업 내용
현재 롤링페이퍼 목록 페이지의 Carousel을 라이브러리 사용하지 않고 직접 구현

## 결과
- 라이브러리 없이 Carousel 반응형 직접 구현
- swiper 라이브러리 의존성 제거

## 작업 범위
- [x] 라이브러리 없이 Carousel 반응형 직접 구현
- [x] swiper 라이브러리 의존성 제거
