### PR TITLE
feat: listPage API 연동 및 데이터 표시 구현

### DIFF
--- a/src/api/ListPage/fetchRecipientData.js
+++ b/src/api/ListPage/fetchRecipientData.js
@@ -1,0 +1,40 @@
+import { handleResponseError } from '../../utils/errorHandler';
+import { HttpException } from '../../utils/exceptions';
+
+const BASE_URL = process.env.REACT_APP_BASE_URL;
+
+const fetchRecipientData = async (limit = 10, offset = 0) => {
+  const params = new URLSearchParams({ limit, offset });
+  params.append('limit', limit);
+  params.append('offset', offset);
+
+  try {
+    const response = await fetch(
+      `${BASE_URL}/recipients/?${params.toString()}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      handleResponseError(response);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    } else {
+      console.error('네트워크 오류', error);
+      throw new Error(
+        '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+      );
+    }
+  }
+};
+
+export default fetchRecipientData;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import './styles/global.css';
 import App from './App';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
-import ListPage from './pages/ListPage/ListPage';
+import ListPageContainer from './pages/ListPage/ListPageContainer';
 import CreatePage from './pages/CreatePage/CreatePage';
 import DetailPage from './pages/DetailPage/DetailPage';
 import EditPage from './pages/EditPage/EditPage';
@@ -22,7 +22,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'list',
-        element: <ListPage />,
+        element: <ListPageContainer />,
       },
       {
         path: 'post',

--- a/src/pages/ListPage/ListPageContainer.js
+++ b/src/pages/ListPage/ListPageContainer.js
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import ListPagePresenter from './ListPagePresenter';
+import fetchRecipientData from '../../api/ListPage/fetchRecipientData';
+import { HttpException } from '../../utils/exceptions';
+
+function ListPageContainer() {
+  const [popularPapers, setPopularPapers] = useState([]);
+  const [recentPapers, setRecentPapers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const { results: allData } = await fetchRecipientData(20, 0);
+        console.log('Fetched Data:', allData);
+
+        const sortedByReactionCount = [...allData].sort(
+          (a, b) => b.reactionCount - a.reactionCount,
+        );
+        setPopularPapers(sortedByReactionCount);
+
+        const sortedByCreatedAt = [...allData].sort(
+          (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
+        );
+        setRecentPapers(sortedByCreatedAt);
+
+        setError(null);
+      } catch (error) {
+        if (error instanceof HttpException) {
+          setError(error.message);
+        } else {
+          setError('알 수 없는 오류가 발생했습니다.');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <ListPagePresenter
+      popularPapers={popularPapers}
+      recentPapers={recentPapers}
+      loading={loading}
+      error={error}
+    />
+  );
+}
+
+export default ListPageContainer;

--- a/src/pages/ListPage/ListPagePresenter.js
+++ b/src/pages/ListPage/ListPagePresenter.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Header from '../../components/layout/Header';
 import Button from '../../components/ui/Button';
-import mockData from '../../data/mockData.json';
 import useResponsive from '../../hooks/useResponsive';
 import useCarousel from '../../hooks/useCarousel';
 import {
@@ -12,25 +11,32 @@ import {
 } from './ListPage.styles';
 import CarouselContainer from './CarouselContainer';
 
-function ListPage() {
+function ListPagePresenter({ popularPapers, recentPapers, loading, error }) {
   const cardsToShow = 4;
   const isMobile = useResponsive(1248);
 
-  // 상단 캐러셀
   const {
     currentIndex: currentIndexTop,
     maxIndex: maxIndexTop,
     handleNext: handleNextTop,
     handlePrev: handlePrevTop,
-  } = useCarousel(mockData.length, cardsToShow);
+  } = useCarousel(popularPapers?.length || 0, cardsToShow);
 
-  // 하단 캐러셀
   const {
     currentIndex: currentIndexBottom,
     maxIndex: maxIndexBottom,
     handleNext: handleNextBottom,
     handlePrev: handlePrevBottom,
-  } = useCarousel(mockData.length, cardsToShow);
+  } = useCarousel(recentPapers?.length || 0, cardsToShow);
+
+  // 로딩 상태 처리
+  if (loading) return <div>로딩 중...</div>;
+
+  // 에러 상태 처리
+  if (error) return <div>{error}</div>;
+
+  // 데이터가 없는 경우 처리
+  if (!popularPapers || !recentPapers) return <div>데이터가 없습니다.</div>;
 
   return (
     <>
@@ -40,7 +46,7 @@ function ListPage() {
           <h2 className="text-xl font-bold">인기 롤링 페이퍼 🔥</h2>
           <ListSection>
             <CarouselContainer
-              data={mockData}
+              data={popularPapers}
               isMobile={isMobile}
               currentIndex={currentIndexTop}
               handlePrev={handlePrevTop}
@@ -55,7 +61,7 @@ function ListPage() {
           <h2 className="text-xl font-bold">최근에 만든 롤링 페이퍼 ⭐️️</h2>
           <ListSection>
             <CarouselContainer
-              data={mockData}
+              data={recentPapers}
               isMobile={isMobile}
               currentIndex={currentIndexBottom}
               handlePrev={handlePrevBottom}
@@ -80,4 +86,4 @@ function ListPage() {
   );
 }
 
-export default ListPage;
+export default ListPagePresenter;

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,0 +1,28 @@
+import {
+  HttpException,
+  BadRequestException,
+  UnauthorizedException,
+  NotFoundException,
+  InternalServerErrorException,
+} from './exceptions';
+
+export const handleResponseError = (response) => {
+  console.error(`HTTP Error: ${response.status} ${response.statusText}`);
+
+  switch (response.status) {
+    case 400:
+      throw new BadRequestException(response);
+    case 401:
+      throw new UnauthorizedException(response);
+    case 404:
+      throw new NotFoundException(response);
+    case 500:
+      throw new InternalServerErrorException(response);
+    default:
+      throw new HttpException(
+        `오류가 발생했습니다. (에러 코드: ${response.status})`,
+        response.status,
+        response,
+      );
+  }
+};

--- a/src/utils/exceptions.js
+++ b/src/utils/exceptions.js
@@ -1,0 +1,41 @@
+const HTTP_STATUS_CODE_MAPPER = {
+  400: '잘못된 요청입니다.',
+  401: '인증이 필요합니다',
+  403: '접근 권한이 없습니다',
+  404: '요청한 상품을 찾을 수 없습니다',
+  500: '서버에 오류가 발생했습니다.',
+};
+
+export class HttpException extends Error {
+  constructor(message, statusCode, response) {
+    super(message);
+    this.name = this.constructor.name;
+    this.statusCode = statusCode;
+    this.response = response;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+export class NotFoundException extends HttpException {
+  constructor(details) {
+    super(HTTP_STATUS_CODE_MAPPER[404], 404, details);
+  }
+}
+
+export class UnauthorizedException extends HttpException {
+  constructor(details) {
+    super(HTTP_STATUS_CODE_MAPPER[401], 401, details);
+  }
+}
+
+export class BadRequestException extends HttpException {
+  constructor(details) {
+    super(HTTP_STATUS_CODE_MAPPER[400], 400, details);
+  }
+}
+
+export class InternalServerErrorException extends HttpException {
+  constructor(details) {
+    super(HTTP_STATUS_CODE_MAPPER[500], 500, details);
+  }
+}


### PR DESCRIPTION
## 작업 설명
ListPage API 연동 및 데이터 표시 구현

Resolves #28 

## 결과
- API를 통해 인기 롤링 페이퍼와 최근에 만든 롤링 페이퍼 데이터를 동적으로 불러와 표시한다.
- 상단과 하단 캐러셀에 각각의 데이터를 올바르게 매핑하여 사용자에게 제공한다.
- 네트워크 오류 또는 데이터가 없을 경우, 적절한 오류 메시지 또는 대체 UI를 표시한다.

## 작업 범위
- [x] 인기 롤링 페이퍼 API 연동 및 데이터 표시
- [x] 최근에 만든 롤링 페이퍼 API 연동 및 데이터 표시
- [x] API 호출 중 로딩 상태 표시
- [x] API 호출 실패 시 오류 처리 및 메시지 표시
- [x] mockData 대신 API로 불러온 데이터를 캐러셀에 적용
- [x] 반응형 UI 및 데이터 연동 테스트
