### PR TITLE
feat/message status bar api #30

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ REACT_APP_BASE_URL=http://localhost:4000
 # 외부 서비스 키 (공개 가능)
 REACT_APP_GOOGLE_MAPS_KEY=AIzaSy123456789
 REACT_APP_FIREBASE_API_KEY=AIzaSyFirebase
+REACT_APP_KAKAO_API_KEY=KakaoApiKey
 
 # 배포 환경 구분
 REACT_APP_ENV=development

--- a/src/api/DetailPage/fetchAddReaction.js
+++ b/src/api/DetailPage/fetchAddReaction.js
@@ -1,0 +1,37 @@
+import { handleResponseError } from '../../utils/errorHandler';
+import { HttpException } from '../../utils/exceptions';
+
+const BASE_URL = process.env.REACT_APP_BASE_URL;
+
+const fetchAddReaction = async (recipientsId, emoji, type) => {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/recipients/${recipientsId}/reactions/`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ emoji, type }),
+      },
+    );
+
+    if (!response.ok) {
+      handleResponseError(response);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    } else {
+      console.error('네트워크 오류', error);
+      throw new Error(
+        '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요',
+      );
+    }
+  }
+};
+
+export default fetchAddReaction;

--- a/src/api/DetailPage/fetchRecipientReactions.js
+++ b/src/api/DetailPage/fetchRecipientReactions.js
@@ -1,0 +1,36 @@
+import { handleResponseError } from '../../utils/errorHandler';
+import { HttpException } from '../../utils/exceptions';
+
+const BASE_URL = process.env.REACT_APP_BASE_URL;
+
+const fetchRecipientReactions = async (recipientsId) => {
+  try {
+    const response = await fetch(
+      `${BASE_URL}/recipients/${recipientsId}/reactions/`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      handleResponseError(response);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    } else {
+      console.error('네트워크 오류', error);
+      throw new Error(
+        '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요',
+      );
+    }
+  }
+};
+
+export default fetchRecipientReactions;

--- a/src/api/DetailPage/fetchRecipientsById.js
+++ b/src/api/DetailPage/fetchRecipientsById.js
@@ -1,0 +1,33 @@
+import { handleResponseError } from '../../utils/errorHandler';
+import { HttpException } from '../../utils/exceptions';
+
+const BASE_URL = process.env.REACT_APP_BASE_URL;
+
+const fetchRecipientById = async (recipientsId) => {
+  try {
+    const response = await fetch(`${BASE_URL}/recipients/${recipientsId}/`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      handleResponseError(response);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    if (error instanceof HttpException) {
+      throw error;
+    } else {
+      console.error('네트워크 오류', error);
+      throw new Error(
+        '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요',
+      );
+    }
+  }
+};
+
+export default fetchRecipientById;

--- a/src/components/layout/MessageStatusBar/MessageStatusBar.style.js
+++ b/src/components/layout/MessageStatusBar/MessageStatusBar.style.js
@@ -91,10 +91,15 @@ export const StatusBarSectionWrapperRight = styled.div`
 
 export const ReactionsWrapper = styled.div`
   display: flex;
+`;
 
-  img {
-    margin-left: 0.8rem;
-  }
+export const AllEmojiButton = styled.img`
+  margin-left: 0.8rem;
+
+  transition: transform 0.3s ease;
+  transform: ${({ isRotated }) =>
+    isRotated ? 'rotate(180deg)' : 'rotate(0deg)'};
+  cursor: pointer; /* 클릭 가능함을 나타내기 위해 커서를 포인터로 변경 */
 `;
 
 export const MessageCount = styled.p`
@@ -125,6 +130,19 @@ export const EmojiSelector = styled.div`
   right: 9rem;
   z-index: 1000;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
+
+  animation: fadeIn 0.3s ease;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 `;
 
 export const ShareDropdownMenu = styled.div`
@@ -137,6 +155,7 @@ export const ShareDropdownMenu = styled.div`
   color: var(--gray-900);
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
   z-index: 1000;
+  animation: fadeIn 0.3s ease;
 
   ul {
     list-style: none;
@@ -150,6 +169,45 @@ export const ShareDropdownMenu = styled.div`
       &:hover {
         background-color: var(--gray-100);
       }
+    }
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`;
+
+export const AllEmojiDropdown = styled.div`
+  position: absolute;
+  top: 100%;
+  right: 16rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: 0.8rem;
+  border: 0.1rem solid #b6b6b6;
+  border-radius: 0.8rem;
+  padding: 2.4rem;
+  background-color: var(--white);
+  gap: 1rem;
+  z-index: 1000;
+  box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
+  animation: fadeIn 0.3s ease;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
     }
   }
 `;

--- a/src/components/layout/MessageStatusBar/MessageStatusBarContainer.js
+++ b/src/components/layout/MessageStatusBar/MessageStatusBarContainer.js
@@ -1,32 +1,118 @@
-import mockData from '../../../data/mockData.json';
 import MessageStatusBarPresenter from './MessageStatusBarPresenter';
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { HttpException } from '../../../utils/exceptions';
+import fetchRecipientReactions from '../../../api/DetailPage/fetchRecipientReactions';
+import fetchRecipientsById from '../../../api/DetailPage/fetchRecipientsById';
+import fetchAddReaction from '../../../api/DetailPage/fetchAddReaction';
 
 function MessageStatusBarContainer() {
-  const firstData = mockData[0];
+  const { id } = useParams();
+  const [recipients, setRecipients] = useState(null);
+  const [reactions, setReactions] = useState([]);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
   const [isEmojiPickerVisible, setEmojiPickerVisible] = useState(false);
   const [isShareDropdownVisible, setShareDropdownVisible] = useState(false);
+  const [isAllEmojisVisible, setAllEmojisVisible] = useState(false);
 
-  const toggleEmojiPicker = () => {
+  const getReactionsById = async () => {
+    try {
+      const data = await fetchRecipientReactions(id);
+      setReactions(data.results);
+    } catch (error) {
+      if (error instanceof HttpException) {
+        setError(error.message);
+      } else {
+        setError('알 수 없는 오류가 발생했습니다.');
+      }
+      throw Error;
+    }
+  };
+
+  const getRecipientById = async () => {
+    try {
+      const data = await fetchRecipientsById(id);
+      setRecipients(data);
+    } catch (error) {
+      if (error instanceof HttpException) {
+        setError(error.message);
+      } else {
+        setError('알 수 없는 오류가 발생했습니다.');
+      }
+      throw Error;
+    }
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        await Promise.all([getRecipientById(), getReactionsById()]);
+      } catch (error) {
+        console.error('Error in fetchData:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (id) {
+      fetchData();
+    }
+  }, [id]);
+
+  const toggleEmojiPicker = useCallback(() => {
     setEmojiPickerVisible((prev) => !prev);
-  };
+  }, []);
 
-  const toggleShareDropdown = () => {
+  const toggleShareDropdown = useCallback(() => {
     setShareDropdownVisible((prev) => !prev);
+  }, []);
+
+  const toggleAllEmojis = useCallback(() => {
+    setAllEmojisVisible((prev) => !prev);
+  }, []);
+
+  const handleEmojiClick = async (emojiObject, event) => {
+    setEmojiPickerVisible(false);
+    const selectedEmoji = emojiObject.emoji;
+
+    try {
+      await fetchAddReaction(id, selectedEmoji, 'increase');
+    } catch (error) {
+      if (error instanceof HttpException) {
+        setError(error.message);
+      } else {
+        setError('알 수 없는 오류가 발생했습니다.');
+      }
+      throw Error;
+    }
   };
 
-  const handleEmojiClick = (event, emojiObject) => {
-    setEmojiPickerVisible(false);
-  };
+  if (loading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (error) {
+    return <div>오류: {error}</div>;
+  }
+
+  if (!recipients) {
+    return <div>수신자를 찾을 수 없습니다.</div>;
+  }
 
   return (
     <MessageStatusBarPresenter
-      data={firstData}
+      recipients={recipients}
+      reactions={reactions}
       isEmojiPickerVisible={isEmojiPickerVisible}
       toggleEmojiPicker={toggleEmojiPicker}
       onEmojiClick={handleEmojiClick}
       isShareDropdownVisible={isShareDropdownVisible}
       toggleShareDropdown={toggleShareDropdown}
+      isAllEmojisVisible={isAllEmojisVisible}
+      toggleAllEmojis={toggleAllEmojis}
     />
   );
 }

--- a/src/components/layout/MessageStatusBar/MessageStatusBarContainer.js
+++ b/src/components/layout/MessageStatusBar/MessageStatusBarContainer.js
@@ -5,6 +5,7 @@ import { HttpException } from '../../../utils/exceptions';
 import fetchRecipientReactions from '../../../api/DetailPage/fetchRecipientReactions';
 import fetchRecipientsById from '../../../api/DetailPage/fetchRecipientsById';
 import fetchAddReaction from '../../../api/DetailPage/fetchAddReaction';
+import useKakaoShare from '../../../hooks/useKakaoShare';
 
 function MessageStatusBarContainer() {
   const { id } = useParams();
@@ -16,6 +17,26 @@ function MessageStatusBarContainer() {
   const [isEmojiPickerVisible, setEmojiPickerVisible] = useState(false);
   const [isShareDropdownVisible, setShareDropdownVisible] = useState(false);
   const [isAllEmojisVisible, setAllEmojisVisible] = useState(false);
+
+  const { shareToKakao } = useKakaoShare();
+
+  // 카카오톡 공유 핸들러
+  const handleKakaoShare = useCallback(() => {
+    shareToKakao();
+  }, [shareToKakao]);
+
+  // URL 공유 핸들러
+  const handleURLShare = useCallback(() => {
+    navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        alert('URL이 클립보드에 복사되었습니다!');
+      })
+      .catch((err) => {
+        console.error('URL 복사 실패:', err);
+        alert('URL 복사에 실패했습니다.');
+      });
+  }, []);
 
   const getReactionsById = async () => {
     try {
@@ -113,6 +134,8 @@ function MessageStatusBarContainer() {
       toggleShareDropdown={toggleShareDropdown}
       isAllEmojisVisible={isAllEmojisVisible}
       toggleAllEmojis={toggleAllEmojis}
+      handleKakaoShare={handleKakaoShare}
+      handleURLShare={handleURLShare}
     />
   );
 }

--- a/src/components/layout/MessageStatusBar/MessageStatusBarPresenter.js
+++ b/src/components/layout/MessageStatusBar/MessageStatusBarPresenter.js
@@ -13,41 +13,57 @@ import {
   ButtonWrapper,
   EmojiSelector,
   ShareDropdownMenu,
+  AllEmojiButton,
+  AllEmojiDropdown,
 } from './MessageStatusBar.style';
 import ProfileImages from '../../common/ProfileImages';
 import Reactions from '../../common/Reactions';
+import EmojiCard from '../../common/EmojiCard';
 import errow_down from '../../../assets/icons/arrow_down.svg';
 import Button from '../../ui/Button';
 import buttonIcon from '../../../assets/icons/button-icon.svg';
 import shareButton from '../../../assets/icons/share-button.svg';
 
 function MessageStatusBarPresenter({
-  data,
   isEmojiPickerVisible,
   toggleEmojiPicker,
   onEmojiClick,
   isShareDropdownVisible,
   toggleShareDropdown,
+  reactions,
+  recipients,
+  isAllEmojisVisible,
+  toggleAllEmojis,
 }) {
   return (
     <StatusBarContainer>
       <StatusBarWrapper>
         <TitleWrapper>
-          <Title className="text-3xl font-bold">To. {data.name}</Title>
+          <Title className="text-3xl font-bold">To. {recipients.name}</Title>
         </TitleWrapper>
 
         <StatusBarSection>
           <StatusBarSectionWrapperLeft>
-            <ProfileImages recentMessages={data.recentMessages}></ProfileImages>
+            <ProfileImages
+              recentMessages={recipients.recentMessages}
+            ></ProfileImages>
             <MessageCount className="text-lg">
-              <strong>{data.messageCount}</strong>명이 작성했어요!
+              <strong>{recipients.messageCount}</strong>명이 작성했어요!
             </MessageCount>
           </StatusBarSectionWrapperLeft>
 
           <StatusBarSectionWrapperRight>
             <ReactionsWrapper>
-              <Reactions topReactions={data.topReactions} noMargin></Reactions>
-              <img src={errow_down} alt="이모지 드롭다운" />
+              <Reactions
+                topReactions={recipients.topReactions}
+                noMargin
+              ></Reactions>
+              <AllEmojiButton
+                src={errow_down}
+                alt="이모지 드롭다운"
+                isRotated={isAllEmojisVisible}
+                onClick={toggleAllEmojis}
+              />
             </ReactionsWrapper>
             <ButtonWrapper>
               <Button
@@ -81,6 +97,18 @@ function MessageStatusBarPresenter({
               <li>URL 공유</li>
             </ul>
           </ShareDropdownMenu>
+        )}
+
+        {isAllEmojisVisible && (
+          <AllEmojiDropdown>
+            {reactions.map((reaction) => (
+              <EmojiCard
+                key={reaction.id}
+                emoji={reaction.emoji}
+                count={reaction.count}
+              />
+            ))}
+          </AllEmojiDropdown>
         )}
       </StatusBarWrapper>
     </StatusBarContainer>

--- a/src/components/layout/MessageStatusBar/MessageStatusBarPresenter.js
+++ b/src/components/layout/MessageStatusBar/MessageStatusBarPresenter.js
@@ -34,6 +34,8 @@ function MessageStatusBarPresenter({
   recipients,
   isAllEmojisVisible,
   toggleAllEmojis,
+  handleKakaoShare,
+  handleURLShare,
 }) {
   return (
     <StatusBarContainer>
@@ -93,8 +95,8 @@ function MessageStatusBarPresenter({
         {isShareDropdownVisible && (
           <ShareDropdownMenu className="text-base">
             <ul>
-              <li>카카오톡 공유</li>
-              <li>URL 공유</li>
+              <li onClick={handleKakaoShare}>카카오톡 공유</li>
+              <li onClick={handleURLShare}>URL 공유</li>
             </ul>
           </ShareDropdownMenu>
         )}

--- a/src/hooks/useKakaoShare.js
+++ b/src/hooks/useKakaoShare.js
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+
+const useKakaoShare = () => {
+  useEffect(() => {
+    if (!window.Kakao) {
+      const script = document.createElement('script');
+      script.src = 'https://developers.kakao.com/sdk/js/kakao.min.js';
+      script.async = true;
+
+      script.onload = () => {
+        if (window.Kakao && !window.Kakao.isInitialized()) {
+          window.Kakao.init(process.env.REACT_APP_KAKAO_API_KEY);
+          console.log('Kakao SDK initialized');
+        }
+      };
+
+      document.body.appendChild(script);
+
+      return () => {
+        document.body.removeChild(script);
+      };
+    } else {
+      if (!window.Kakao.isInitialized()) {
+        window.Kakao.init(process.env.REACT_APP_KAKAO_API_KEY);
+        console.log('Kakao SDK initialized');
+      }
+    }
+  }, []);
+
+  const shareToKakao = () => {
+    if (window.Kakao && window.Kakao.isInitialized()) {
+      window.Kakao.Share.sendDefault({
+        objectType: 'feed',
+        content: {
+          title: '🎉 롤링페이퍼로 마음을 전해보세요!',
+          description:
+            '친구들과 함께 소중한 순간을 롤링페이퍼에 담아보세요. 축하 메시지로 특별한 날을 더욱 빛내세요!',
+          imageUrl:
+            'https://cdn.sayun.studio/boottent/files/assets/codeit/portfolio/articles_bef5234f-f7c2-4f63-9f34-2d58703f1519.png',
+          link: {
+            mobileWebUrl: window.location.href,
+            webUrl: window.location.href,
+          },
+        },
+        buttons: [
+          {
+            title: '웹으로 보기',
+            link: {
+              mobileWebUrl: window.location.href,
+              webUrl: window.location.href,
+            },
+          },
+        ],
+      });
+    } else {
+      console.error('Kakao SDK가 초기화되지 않았습니다.');
+    }
+  };
+
+  return { shareToKakao };
+};
+
+export default useKakaoShare;

--- a/src/pages/DetailPage/DetailPage.js
+++ b/src/pages/DetailPage/DetailPage.js
@@ -36,7 +36,7 @@ function DetailPage() {
           />
         </DetailPageCardContainer>
       </DetailPageContainer>
-      {selectedCard && <Modal card={selectedCard} onClose={closeModal} />}]
+      {selectedCard && <Modal card={selectedCard} onClose={closeModal} />}
     </>
   );
 }


### PR DESCRIPTION
## 작업 설명
("/post") 페이지의 MessageStatusBar API 연동 및 데이터 표시 구현

Resolves #30 

## 결과
- API를 통해 롤링 페이퍼의 상태 렌더링 
- 카카오톡 공유 기능 추가
- URL 링크 공유 추가 
- 드롭다운 애니메이션 추가

## 작업 범위
- [x] API를 통해 롤링 페이퍼의 상태 렌더링 
- [x] 공유 기능 추가