### PR TITLE
fix: 카카오 SDK 초기화 오류 방지를 위해 index.html에서 직접 로드

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
       rel="stylesheet"
     />
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
     <title>Rolling</title>
   </head>
   <body>

--- a/src/hooks/useKakaoShare.js
+++ b/src/hooks/useKakaoShare.js
@@ -2,28 +2,9 @@ import { useEffect } from 'react';
 
 const useKakaoShare = () => {
   useEffect(() => {
-    if (!window.Kakao) {
-      const script = document.createElement('script');
-      script.src = 'https://developers.kakao.com/sdk/js/kakao.min.js';
-      script.async = true;
-
-      script.onload = () => {
-        if (window.Kakao && !window.Kakao.isInitialized()) {
-          window.Kakao.init(process.env.REACT_APP_KAKAO_API_KEY);
-          console.log('Kakao SDK initialized');
-        }
-      };
-
-      document.body.appendChild(script);
-
-      return () => {
-        document.body.removeChild(script);
-      };
-    } else {
-      if (!window.Kakao.isInitialized()) {
-        window.Kakao.init(process.env.REACT_APP_KAKAO_API_KEY);
-        console.log('Kakao SDK initialized');
-      }
+    if (window.Kakao && !window.Kakao.isInitialized()) {
+      window.Kakao.init(process.env.REACT_APP_KAKAO_API_KEY);
+      console.log('Kakao SDK initialized');
     }
   }, []);
 


### PR DESCRIPTION
## 작업 설명
Kakao SDK 초기화 오류 방지를 위해 index.html에서 직접 로드

Resolves #34 

## 결과
- index.html에서 직접 스크립트를 추가해 안정적인 SDK 초기화