### PR TITLE
Fix: detailPage의 카드 렌더링 문제 해결 및 modal 반응형 수정 

### DIFF
--- a/q
+++ b/q
@@ -1,0 +1,7 @@
+* [32mdev[m
+  feat/detailPage-add-button-Scroll-07[m
+  feat/detailPage-add-editBtn-12[m
+  feat/detailPage-api-25[m
+  feat/detailPage-api-connect-25[m
+  feat/detailPage-modal-ui-15[m
+  feat/frame-detailpage-04[m

--- a/src/api/DetailPage/fetchMessagesForRecipient.js
+++ b/src/api/DetailPage/fetchMessagesForRecipient.js
@@ -3,10 +3,14 @@ import { HttpException } from '../../utils/exceptions';
 
 const BASE_URL = process.env.REACT_APP_BASE_URL;
 
-const fetchRecipientById = async (recipientsId) => {
+const fetchMessagesForRecipient = async (
+  recipientId,
+  limit = 100,
+  offset = 0,
+) => {
   try {
     const response = await fetch(
-      `${BASE_URL}/recipients/${recipientsId}/?limit=5&offset=0`,
+      `${BASE_URL}/recipients/${recipientId}/messages/?limit=${limit}&offset=${offset}`,
       {
         method: 'GET',
         headers: {
@@ -33,4 +37,4 @@ const fetchRecipientById = async (recipientsId) => {
   }
 };
 
-export default fetchRecipientById;
+export default fetchMessagesForRecipient;

--- a/src/pages/DetailPage/DetailPage.js
+++ b/src/pages/DetailPage/DetailPage.js
@@ -11,6 +11,7 @@ import {
   DetailPageEditBtnContainer,
 } from './DetailPage.style';
 import MessageStatusBarContainer from '../../components/layout/MessageStatusBar/MessageStatusBarContainer';
+import fetchMessagesForRecipient from '../../api/DetailPage/fetchMessagesForRecipient';
 
 function DetailPage() {
   const { id } = useParams();
@@ -18,6 +19,7 @@ function DetailPage() {
   const [recipientData, setRecipientData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [messages, setMessages] = useState([]);
 
   const handleCardClick = (card) => {
     setSelectedCard(card);
@@ -32,6 +34,8 @@ function DetailPage() {
       try {
         const recipient = await fetchRecipientById(id);
         setRecipientData({ ...recipient });
+        const allMessages = await fetchMessagesForRecipient(id); // 메세지 데이터 가져오기
+        setMessages(allMessages.results || []); // 메세지 목록 저장
         setError(null);
       } catch (error) {
         setError(error.message);
@@ -62,7 +66,7 @@ function DetailPage() {
         <DetailPageCardContainer>
           <DetailPageCards
             id={id}
-            cardData={recipientData?.recentMessages || []}
+            cardData={messages || []}
             onCardClick={handleCardClick}
           />
         </DetailPageCardContainer>

--- a/src/pages/DetailPage/DetailPage.style.js
+++ b/src/pages/DetailPage/DetailPage.style.js
@@ -54,52 +54,8 @@ export const DetailPageCardContainer = styled.div`
   }
 `;
 
-export const DetailPageCard = styled.div`
-  width: 38.4rem;
-  height: auto; //height: 28rem;
-  border-radius: 1.6rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.6rem;
-  background-color: white;
-  border: none;
-  cursor: pointer;
-
-  @media (max-width: 1248px) {
-    width: calc((100% - 1.6rem) / 2);
-    height: 28.4rem;
-  }
-
-  @media (max-width: 768px) {
-    width: 100%;
-    height: 23rem;
-  }
-`;
-
 export const DetailPageEditBtn = styled(Button)`
   width: 9.2rem;
-`;
-
-export const DetailPageCardProfile = styled.div`
-  width: 17.9rem;
-  height: 5.6rem;
-  margin-left: 2.4rem;
-  margin-top: 2.8rem;
-  display: flex;
-  justify-content: space-between;
-`;
-
-export const DetailPageCardProfileImg = styled.div`
-  width: 5.6rem;
-  height: 5.6rem;
-  border-radius: 10rem;
-  overflow: hidden;
-`;
-
-export const DetailPageCardProfileImgImage = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover; // 이미지 비율을 유지하며, div 영역을 꽉 채움
 `;
 
 export const DetailPageEditBtnContainer = styled.div`
@@ -112,52 +68,6 @@ export const DetailPageEditBtnContainer = styled.div`
   @media (max-width: 1248px) {
     width: calc(100% - 4.8rem);
     gap: 1.6rem;
-  }
-
-  @media (max-width: 768px) {
-    width: calc(100% - 4.8rem);
-  }
-`;
-
-export const DetailPageCardCreateBtn = styled(Link)`
-  width: 38.4rem;
-  height: 28rem;
-  border-radius: 1.6rem;
-  background-color: white;
-  border: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-
-  @media (max-width: 1248px) {
-    width: calc((50% - 0.8rem));
-    height: 28.4rem;
-  }
-
-  @media (max-width: 768px) {
-    width: 100%;
-    height: 23rem;
-  }
-`;
-
-export const DetailPageCardProfileWho = styled.div`
-  width: 10.9rem;
-  height: 5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-`;
-
-export const DetailPageCardTextContainer = styled.div`
-  width: 33.6rem;
-  height: 12.2rem;
-  border-top: 1px solid #eeeeee; // 수정된 부분
-  margin: 0 auto;
-  overflow: hidden; // 넘치는 내용 숨기기
-  text-overflow: ellipsis; // 넘치는 글자를 '...'으로 표시
-  @media (max-width: 1248px) {
-    width: calc(100% - 4.8rem);
   }
 
   @media (max-width: 768px) {
@@ -188,28 +98,4 @@ export const DetailPageCardText = styled.div`
       width: 100%;
     }
   }
-`;
-
-export const DetailPageCardDate = styled.div`
-  width: 6rem;
-  height: 1.8rem;
-  margin-left: 2.4rem;
-  white-space: nowrap; /* 줄 바꿈 방지 */
-  color: var(--gray-400);
-
-  @media (max-width: 768px) {
-    margin-bottom: 2.4rem;
-  }
-`;
-
-export const DetailPageCardProfileWhoFrom = styled.div`
-  width: 100%;
-  height: 2.4rem;
-  display: flex;
-  justify-content: space-between;
-`;
-
-export const DetailPageCardProfileWhoRelation = styled.div`
-  width: 4.1rem;
-  height: 2rem;
 `;

--- a/src/pages/DetailPage/DetailPage.style.js
+++ b/src/pages/DetailPage/DetailPage.style.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 import Button from '../../components/ui/Button';
 
 export const DetailPageContainer = styled.div`

--- a/src/pages/DetailPage/DetailPageModal.style.js
+++ b/src/pages/DetailPage/DetailPageModal.style.js
@@ -11,6 +11,10 @@ export const ModalOverlay = styled.div`
   display: flex;
   justify-content: center;
   z-index: 1000;
+
+  @media (max-width: 768px) {
+    display: none; /* 모바일 화면에서는 모달 오버레이 숨기기 */
+  }
 `;
 
 export const ModalContent = styled.div`
@@ -18,12 +22,18 @@ export const ModalContent = styled.div`
   border-radius: 1.6rem;
   width: 60rem;
   height: 47.6rem;
-  position: relative;
-  top: 28rem;
+  position: absolute;
+  top: 8.5rem;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
   display: flex;
   flex-direction: column;
+  left: 50%;
+  transform: translateX(-50%);
   align-items: center;
+
+  @media (max-width: 1248px) {
+    top: 5rem;
+  }
 `;
 
 export const ModalBtn = styled(Button)`

--- a/src/pages/EditPage/EditPage.js
+++ b/src/pages/EditPage/EditPage.js
@@ -10,18 +10,23 @@ import {
   DetailPageEditBtnContainer,
 } from '../DetailPage/DetailPage.style';
 import MessageStatusBarContainer from '../../components/layout/MessageStatusBar/MessageStatusBarContainer';
+import fetchMessagesForRecipient from '../../api/DetailPage/fetchMessagesForRecipient';
 
 function EditPage() {
   const { id } = useParams();
   const [recipientData, setRecipientData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [messages, setMessages] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const recipient = await fetchRecipientById(id);
         setRecipientData({ ...recipient });
+        const allMessages = await fetchMessagesForRecipient(id); // 메세지 데이터 가져오기
+        setMessages(allMessages.results || []); // 메세지 목록 저장
+
         setError(null);
       } catch (error) {
         setError(error.message);
@@ -50,10 +55,7 @@ function EditPage() {
           <EditPageAllDeleteButton recipientId={id} />
         </DetailPageEditBtnContainer>
         <DetailPageCardContainer>
-          <EditPageCards
-            id={id}
-            cardData={recipientData?.recentMessages || []}
-          />
+          <EditPageCards id={id} cardData={messages || []} />
         </DetailPageCardContainer>
       </DetailPageContainer>
     </>


### PR DESCRIPTION
## 작업 설명
#48 
- detailPage의 card가 3개 이상 적용이 안되는 문제 해결
- 모바일 시 모달 기능 제거
- 모달의 위치 수정 

## 해결방법 
- 기존의 렌더링 하고 있던 코드는 최근 메세지 3개만 불러오고 있었음
- 따라서, id에 따른 메세지 조회 api를 추가하여 **fetchMessagesForRecipient.js** 작성 
- detialPage와 editPage에서 메세지 조회를 거친 후 전체 메세지를 가져오게 수정함.

## 특이사항 
-  MessageStatusBar 작업은 성락님께서 도와주신다고 하셨습니다.
-  우선 1차적으로 마무리가 된거 같고, refactor 느낌으로 다가가면 될 것 같습니다.

## 남은문제 
- 삭제하기 권한에 대해서 .. 고민인게 editPage 접근 자체를 lock거는것보다는 접근은 누구나 가능하되,
- a. **message 삭제** -> 메세지 작성한 사용자만 삭제 가능하게 하는게 좋아보이고,
- b. **롤링페이퍼 전체 삭제**  -> 롤링페이퍼 작성한 사용자만 삭제 가능하게 하는 것이 좋아보입니다.

