### PR TITLE
Refactor/message status bar #49

### DIFF
--- a/src/components/common/EmojiCard.js
+++ b/src/components/common/EmojiCard.js
@@ -17,6 +17,10 @@ const EmojiCardWrapper = styled.div`
     width: 1.6rem;
     height: 2.1rem;
   }
+
+  @media (max-width: 768px) {
+    max-width: 5.5rem;
+  }
 `;
 
 function EmojiCard({ emoji, count }) {

--- a/src/components/layout/MessageStatusBar/MessageStatusBar.style.js
+++ b/src/components/layout/MessageStatusBar/MessageStatusBar.style.js
@@ -19,7 +19,8 @@ export const StatusBarWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 120rem;
+  width: 100%;
+  max-width: 120rem;
 
   @media (max-width: 1248px) {
     width: 100%;
@@ -85,15 +86,18 @@ export const StatusBarSectionWrapperRight = styled.div`
 
   @media (max-width: 768px) {
     width: 100%;
-    padding: 1.2rem 2.4rem;
+    padding: 1.2rem 0.4rem;
   }
 `;
 
 export const ReactionsWrapper = styled.div`
   display: flex;
+  min-width: 6rem;
 `;
 
 export const AllEmojiButton = styled.img`
+  width: 2.4rem;
+  height: 3.7rem;
   margin-left: 0.8rem;
 
   transition: transform 0.3s ease;
@@ -108,6 +112,10 @@ export const MessageCount = styled.p`
 
 export const EmojiDropDown = styled.img`
   margin-right: 0.4rem;
+
+  @media (max-width: 768px) {
+    margin: 0;
+  }
 `;
 
 export const ButtonWrapper = styled.div`
@@ -142,6 +150,11 @@ export const EmojiSelector = styled.div`
       opacity: 1;
       transform: translateY(0);
     }
+  }
+
+  @media (max-width: 768px) {
+    top: 100%;
+    right: 0.5rem;
   }
 `;
 
@@ -209,5 +222,16 @@ export const AllEmojiDropdown = styled.div`
       opacity: 1;
       transform: translateY(0);
     }
+  }
+
+  @media (max-width: 768px) {
+    top: 90%;
+    right: 5rem;
+  }
+`;
+
+export const AddText = styled.span`
+  @media (max-width: 768px) {
+    display: none;
   }
 `;

--- a/src/components/layout/MessageStatusBar/MessageStatusBarContainer.js
+++ b/src/components/layout/MessageStatusBar/MessageStatusBarContainer.js
@@ -1,5 +1,5 @@
 import MessageStatusBarPresenter from './MessageStatusBarPresenter';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { HttpException } from '../../../utils/exceptions';
 import fetchRecipientReactions from '../../../api/DetailPage/fetchRecipientReactions';
@@ -7,6 +7,7 @@ import fetchRecipientsById from '../../../api/DetailPage/fetchRecipientsById';
 import fetchAddReaction from '../../../api/DetailPage/fetchAddReaction';
 import useKakaoShare from '../../../hooks/useKakaoShare';
 import ToastContainer from '../../common/Toast';
+import useOutsideClick from '../../../hooks/useOutsideClick';
 
 function MessageStatusBarContainer() {
   const { id } = useParams();
@@ -20,6 +21,10 @@ function MessageStatusBarContainer() {
   const [isAllEmojisVisible, setAllEmojisVisible] = useState(false);
 
   const { shareToKakao } = useKakaoShare();
+
+  const emojiPickerRef = useRef(null);
+  const shareDropdownRef = useRef(null);
+  const allEmojiDropdownRef = useRef(null);
 
   // 카카오톡 공유 핸들러
   const handleKakaoShare = useCallback(
@@ -100,6 +105,23 @@ function MessageStatusBarContainer() {
     setAllEmojisVisible((prev) => !prev);
   }, []);
 
+  const closeDropdowns = useCallback(() => {
+    if (isEmojiPickerVisible) toggleEmojiPicker();
+    if (isShareDropdownVisible) toggleShareDropdown();
+    if (isAllEmojisVisible) toggleAllEmojis();
+  }, [
+    isEmojiPickerVisible,
+    isShareDropdownVisible,
+    isAllEmojisVisible,
+    toggleEmojiPicker,
+    toggleShareDropdown,
+    toggleAllEmojis,
+  ]);
+
+  useOutsideClick(emojiPickerRef, closeDropdowns);
+  useOutsideClick(shareDropdownRef, closeDropdowns);
+  useOutsideClick(allEmojiDropdownRef, closeDropdowns);
+
   const handleEmojiClick = async (emojiObject, event, addToast) => {
     setEmojiPickerVisible(false);
     const selectedEmoji = emojiObject.emoji;
@@ -146,6 +168,9 @@ function MessageStatusBarContainer() {
           toggleAllEmojis={toggleAllEmojis}
           handleKakaoShare={() => handleKakaoShare(addToast)}
           handleURLShare={() => handleURLShare(addToast)}
+          emojiPickerRef={emojiPickerRef}
+          shareDropdownRef={shareDropdownRef}
+          allEmojiDropdownRef={allEmojiDropdownRef}
         />
       )}
     </ToastContainer>

--- a/src/components/layout/MessageStatusBar/MessageStatusBarPresenter.js
+++ b/src/components/layout/MessageStatusBar/MessageStatusBarPresenter.js
@@ -15,7 +15,7 @@ import {
   ShareDropdownMenu,
   AllEmojiButton,
   AllEmojiDropdown,
-  ButtonText,
+  AddText,
 } from './MessageStatusBar.style';
 import ProfileImages from '../../common/ProfileImages';
 import Reactions from '../../common/Reactions';
@@ -37,6 +37,9 @@ function MessageStatusBarPresenter({
   toggleAllEmojis,
   handleKakaoShare,
   handleURLShare,
+  emojiPickerRef,
+  shareDropdownRef,
+  allEmojiDropdownRef,
 }) {
   return (
     <StatusBarContainer>
@@ -76,7 +79,7 @@ function MessageStatusBarPresenter({
                 onClick={toggleEmojiPicker}
               >
                 <EmojiDropDown src={buttonIcon} alt="추가 버튼" />
-                추가
+                <AddText>추가</AddText>
               </Button>
             </ButtonWrapper>
             <Button size="36" variant="outlined" onClick={toggleShareDropdown}>
@@ -87,14 +90,14 @@ function MessageStatusBarPresenter({
 
         {/* 이모지 선택 창 */}
         {isEmojiPickerVisible && (
-          <EmojiSelector>
+          <EmojiSelector ref={emojiPickerRef}>
             <EmojiPicker onEmojiClick={onEmojiClick} />
           </EmojiSelector>
         )}
 
         {/* 공유 드롭다운 메뉴 */}
         {isShareDropdownVisible && (
-          <ShareDropdownMenu className="text-base">
+          <ShareDropdownMenu ref={shareDropdownRef} className="text-base">
             <ul>
               <li onClick={handleKakaoShare}>카카오톡 공유</li>
               <li onClick={handleURLShare}>URL 공유</li>
@@ -103,7 +106,7 @@ function MessageStatusBarPresenter({
         )}
 
         {isAllEmojisVisible && (
-          <AllEmojiDropdown>
+          <AllEmojiDropdown ref={allEmojiDropdownRef}>
             {reactions.map((reaction) => (
               <EmojiCard
                 key={reaction.id}

--- a/src/hooks/useOutsideClick.js
+++ b/src/hooks/useOutsideClick.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+function useOutsideClick(ref, handler) {
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        handler();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [ref, handler]);
+}
+
+export default useOutsideClick;


### PR DESCRIPTION
## 작업 설명
MessageStatusBar refactoring

Resolves #49 

## 결과
- MessageStatusBar 데이터 없을때 화면 깨지는 현상 수정
- MessageStatusBar 드롭다운 화면 바깥 클릭시 사라지게 수정
- MessageStatusBar 모든 이모지 최대 8개까지만 렌더링되게 수정
- MessageStatusBar 모든 이모지 count 순서대로 렌더링되게 리팩토링

## 작업 범위
- [x] MessageStatusBar 데이터 없을때 화면 깨지는 현상 수정
- [x] MessageStatusBar 드롭다운 화면 바깥 클릭시 사라지게 수정
- [x] MessageStatusBar 모든 이모지 최대 8개까지만 렌더링되게 수정
- [x] MessageStatusBar 모든 이모지 count 순서대로 렌더링되게 리팩토링
